### PR TITLE
Removed share button moving logic

### DIFF
--- a/Grapevine-130/Grapevine-130/Controller/ViewController.swift
+++ b/Grapevine-130/Grapevine-130/Controller/ViewController.swift
@@ -940,11 +940,9 @@ extension ViewController: UITableViewDataSource, UITableViewDelegate {
         if (Constants.userID == posts[indexPath.row].poster && currentMode != "myComments"){
             cell.enableDelete()
             cell.disableInteraction()
-            cell.moveShareButton()      //Make share button on the side
         } else {
             cell.disableDelete()
             cell.enableInteraction()
-            cell.revertShareButton()
         }
         
         // If currentmode is my comments then they don't need the cell footer

--- a/Grapevine-130/Grapevine-130/View/PostTableViewCell.swift
+++ b/Grapevine-130/Grapevine-130/View/PostTableViewCell.swift
@@ -159,14 +159,6 @@ class PostTableViewCell: UITableViewCell {
         abilitiesButton.isHidden = true
     }
     
-    //Sets the location of the share button to where the abilities button normally is for when the user is looking at their own post
-    func moveShareButton(){
-        shareButtonVar.trailingAnchor.constraint(equalTo: shareButtonVar.superview!.trailingAnchor, constant: -8).isActive = true
-    }
-    func revertShareButton(){
-        shareButtonVar.trailingAnchor.constraint(equalTo: shareButtonVar.superview!.trailingAnchor, constant: -44).isActive = true
-    }
-    
     
     func enableInteraction() {
         DispatchQueue.main.async {


### PR DESCRIPTION
We don't need it now because the share button is on the edge of the post cell anyways